### PR TITLE
Add improved UK phone number validation and unit tests

### DIFF
--- a/app/Rules/UkPhoneNumber.php
+++ b/app/Rules/UkPhoneNumber.php
@@ -30,7 +30,7 @@ class UkPhoneNumber implements ValidationRule
             $fail(__('validation.string'));
         }
 
-        if (preg_match('/^0([1-6][0-9]{5,9}|7[0-9]{5,9}|8[0-9]{5,9})$/', $value) !== 1) {
+        if (preg_match('/^\(?(\+44|0)?[\s-]?(?:\d{2}|\d{3}|\d{4})[\s-]?\d{3}[\s-]?\d{3}$|^\(?(\+44|0)?[\s-]?\d{6}$|^\(?(\+44|0)?[\s-]?\d{10}$/', $value) !== 1) {
             $fail($this->message());
         }
     }

--- a/tests/Unit/Rules/UkPhoneNumberTest.php
+++ b/tests/Unit/Rules/UkPhoneNumberTest.php
@@ -1,0 +1,64 @@
+<?php
+
+namespace Tests\Unit\Rules;
+
+use App\Rules\UkPhoneNumber;
+use PHPUnit\Framework\TestCase;
+
+class UkPhoneNumberTest extends TestCase
+{
+    public function test_uk_phone_number_validation_accepts_six_digits(): void
+    {
+        $rule = new UkPhoneNumber;
+        $number = '116123';
+
+        $failed = false;
+
+        $rule->validate('phone_number', $number, function () use (&$failed) {
+            $failed = true;
+        });
+
+        $this->assertFalse($failed);
+    }
+
+    public function test_uk_mobile_phone_number_validation(): void
+    {
+        $rule = new UkPhoneNumber;
+        $standardMobileNumber = '07700900123';
+        $mobileNumberWithPlus = '+447700900123';
+
+        $failed = false;
+        $rule->validate('phone_number', $standardMobileNumber, function () use (&$failed) {
+            $failed = true;
+        });
+        $this->assertFalse($failed);
+
+        $failed = false;
+        $rule->validate('phone_number', $mobileNumberWithPlus, function () use (&$failed) {
+            $failed = true;
+        });
+        $this->assertFalse($failed);
+    }
+
+    public function test_uk_phone_number_validation_rejects_seven_digits(): void
+    {
+        $rule = new UkPhoneNumber;
+        $number = '1161234';
+        $failed = false;
+        $rule->validate('phone_number', $number, function () use (&$failed) {
+            $failed = true;
+        });
+        $this->assertTrue($failed);
+    }
+
+    public function test_uk_phone_number_validation_accepts_landline_numbers(): void
+    {
+        $rule = new UkPhoneNumber;
+        $number = '02079460000';
+        $failed = false;
+        $rule->validate('phone_number', $number, function () use (&$failed) {
+            $failed = true;
+        });
+        $this->assertFalse($failed);
+    }
+}


### PR DESCRIPTION
### Summary

https://ayup.atlassian.net/jira/software/projects/ACD/boards/8?selectedIssue=ACD-418

Refined the UK phone number regex to handle various valid formats, including mobile, landline, and short six-digit numbers. Added comprehensive unit tests to ensure the rule correctly validates or rejects different cases.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
