### PR TITLE
Make `image_file_id` nullable in requests and update logic.

### DIFF
--- a/app/Http/Controllers/Core/V1/CollectionOrganisationEventController.php
+++ b/app/Http/Controllers/Core/V1/CollectionOrganisationEventController.php
@@ -85,7 +85,7 @@ class CollectionOrganisationEventController extends Controller
                 'enabled' => $request->enabled,
             ]);
 
-            if ($request->filled('image_file_id')) {
+            if ($request->filled('image_file_id') && $request->get('image_file_id') !== null) {
                 File::findOrFail($request->image_file_id)->assigned();
             }
 

--- a/app/Http/Requests/CollectionOrganisationEvent/StoreRequest.php
+++ b/app/Http/Requests/CollectionOrganisationEvent/StoreRequest.php
@@ -41,6 +41,7 @@ class StoreRequest extends FormRequest
             'category_taxonomies' => ['present', 'array'],
             'category_taxonomies.*' => ['string', 'exists:taxonomies,id', new RootTaxonomyIs(Taxonomy::NAME_CATEGORY)],
             'image_file_id' => [
+                'nullable',
                 'exists:files,id',
                 new FileIsMimeType(File::MIME_TYPE_PNG, File::MIME_TYPE_JPG, File::MIME_TYPE_JPEG, File::MIME_TYPE_SVG),
                 new FileIsPendingAssignment,

--- a/app/Http/Requests/CollectionOrganisationEvent/UpdateRequest.php
+++ b/app/Http/Requests/CollectionOrganisationEvent/UpdateRequest.php
@@ -55,6 +55,7 @@ class UpdateRequest extends FormRequest
             'category_taxonomies' => ['present', 'array'],
             'category_taxonomies.*' => ['string', 'exists:taxonomies,id', new RootTaxonomyIs(Taxonomy::NAME_CATEGORY)],
             'image_file_id' => [
+                'nullable',
                 'exists:files,id',
                 new FileIsMimeType(File::MIME_TYPE_PNG, File::MIME_TYPE_JPG, File::MIME_TYPE_JPEG, File::MIME_TYPE_SVG),
                 new FileIsPendingAssignment(function ($file) {


### PR DESCRIPTION


### Summary

https://ayup.atlassian.net/jira/software/projects/ACD/boards/8?selectedIssue=ACD-416&sprintStarted=true

Allow `image_file_id` to be nullable in `StoreRequest` and `UpdateRequest` validation rules. Adjust logic in the controller to handle cases where `image_file_id` is explicitly null. This ensures greater flexibility for handling optional image uploads.

### Development checklist

- [ ] Changes have been made to the API?
  - [ ] If so, the OpenAPI specification has been updated
- [ ] Database migrations have been added?
  - [ ] If so, the MySQL Workbench ERD has been updated
- [ ] The code has been linted `./develop composer fix:style`

### Release checklist

If there are any actions that must be performed as part of the release, then
create a checklist for them here.

### Notes

If there are any further notes about the PR then write them here.
